### PR TITLE
fix ResourceDir path to be relative to extension dir

### DIFF
--- a/scripts/StylePile.py
+++ b/scripts/StylePile.py
@@ -37,11 +37,11 @@ import modules.scripts as scripts
 import gradio as gr
 from modules.processing import Processed, process_images
 from modules.shared import cmd_opts, opts, state
+from modules import scripts
 
 # =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=->
 
-file_dir = os.path.dirname(os.path.realpath("__file__"))
-ResourceDir = os.path.join(file_dir, f"extensions/StylePile/StylePile/")
+ResourceDir = os.path.join(scripts.basedir(), f"StylePile/")
 
 def FilesInFolder(SourceFolder):
     return [file for file in os.listdir(SourceFolder)]


### PR DESCRIPTION
the webui exposes `scripts.basedir()` to get the base directory of the extension, which is safer to use than relying on `__file__`

`__file__` was also previously not correctly set by the webui which is fixed in AUTOMATIC1111/stable-diffusion-webui#7199, and in turn breaks this extension.